### PR TITLE
align with react v16 API changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,7 @@
 var React = require('react')
+const createReactClass = require('create-react-class')
+const PropTypes = require('prop-types')
+const ReactDOM = require('react-dom-factories')
 
 var styles = {
   modal: {
@@ -20,10 +23,10 @@ var styles = {
   }
 }
 
-module.exports = React.createClass({
+module.exports = createReactClass({
   propTypes: {
-    dismiss: React.PropTypes.func,
-    unstyled: React.PropTypes.bool
+    dismiss: PropTypes.func,
+    unstyled: PropTypes.bool
   },
 
   getDefaultProps: function () {
@@ -56,8 +59,8 @@ module.exports = React.createClass({
 
   render: function () {
     return (
-      React.DOM.div({ className: this.props.overlayClassName, style: this.props.unstyled ? null : this.props.overlayStyle, onClick: this.props.dismiss},
-        React.DOM.div({ className: this.props.modalClassName, style: this.props.unstyled ? null : this.props.modalStyle, onClick: this.doNotPropogate},
+      ReactDOM.div({ className: this.props.overlayClassName, style: this.props.unstyled ? null : this.props.overlayStyle, onClick: this.props.dismiss},
+        ReactDOM.div({ className: this.props.modalClassName, style: this.props.unstyled ? null : this.props.modalStyle, onClick: this.doNotPropogate},
           this.props.children
         )
       )

--- a/package.json
+++ b/package.json
@@ -20,5 +20,10 @@
   "bugs": {
     "url": "https://github.com/rt2zz/react-dumb-modal/issues"
   },
-  "homepage": "https://github.com/rt2zz/react-dumb-modal"
+  "homepage": "https://github.com/rt2zz/react-dumb-modal",
+  "dependencies": {
+    "create-react-class": "^15.6.2",
+    "prop-types": "^15.6.0",
+    "react-dom-factories": "^1.0.2"
+  }
 }


### PR DESCRIPTION
React.DOM and React.createClass are removed from the React module with v16 and put in separate modules. PR aligns with those changes.