### PR TITLE
Fix compatibility with older browser versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var React = require('react')
-const createReactClass = require('create-react-class')
-const PropTypes = require('prop-types')
-const ReactDOM = require('react-dom-factories')
+var createReactClass = require('create-react-class')
+var PropTypes = require('prop-types')
+var ReactDOM = require('react-dom-factories')
 
 var styles = {
   modal: {


### PR DESCRIPTION
Mixing `const` and `var` can trigger bugs in older browsers, e.g. Chrome 53.

To be precise when executing this code with mixed `const` and `var` in Chrome 53
as part of a webpack bundle with a webpack `devtool` setting, the code will throw
"Uncaught ReferenceError: styles is not defined" in the `getDefaultProps` function.

Alternatively using `const` everywhere would also work.